### PR TITLE
Add PF_SOURCE as a way to extend pfetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,11 @@ PF_ALIGN=""
 # Valid: string
 PF_ASCII="openbsd"
 
+# A file to source before calling the main function
+# Default: unset (none)
+# Valid: filepath
+PF_SOURCE=""
+
 # The below environment variables control more
 # than just 'pfetch' and can be passed using
 # 'HOSTNAME=cool_pc pfetch' to restrict their

--- a/pfetch
+++ b/pfetch
@@ -1451,4 +1451,8 @@ main() {
     done >&6
 }
 
+if [ ! -z "$PF_SOURCE" ]; then
+    . "$PF_SOURCE"
+fi
+
 main "$@"


### PR DESCRIPTION
This came from a want to add my own `get_x` functions and then use them with `export PF_INFO`