### PR TITLE
cpu: added get_cpu

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -115,6 +115,37 @@ get_title() {
     log "[3${PF_COL3:-1}m${user}${c7}@[3${PF_COL3:-1}m${hostname}" " " >&6
 }
 
+get_cpu() {
+    case $os in
+        Linux*)
+            cpu_model=$(grep 'model name' /proc/cpuinfo | uniq | sed 's/.*://')
+            #cpu_cores=$(grep 'cpu cores' /proc/cpuinfo | uniq | sed 's/.*://' | awk '{$1=$1;print}')
+            #cpu_threads=$(grep -c processor /proc/cpuinfo)
+            ryzen="Ryzen"
+            if test "${cpu_model#*$ryzen}" != "$cpu_model"
+            then
+                cpu_freq=$(cat /sys/devices/system/cpu/cpu0/cpufreq/bios_limit)
+                cpu_freq=$((cpu_freq / 10000))
+                cpu_freq=$(echo $cpu_freq | sed -e "s/.\{1\}/&./1")
+                cpu_model=$cpu_model" @ $cpu_freq""Ghz"
+            fi
+            ;;
+        *)
+            cpu_model="unsupported"
+            ;;
+    esac
+
+    cpu_model=$(echo $cpu_model | sed -e s/"Dual-Core Processor"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"Quad-Core Processor"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"Six-Core Processor"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"Eight-Core Processor"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"(TM)"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"(tm)"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"(R)"//)
+    cpu_model=$(echo $cpu_model | sed -e s/"(r)"//)
+    log cpu "$cpu_model" >&6
+}
+
 get_os() {
     # This function is called twice, once to detect the distribution name
     # for the purposes of picking an ascii art early and secondly to display


### PR DESCRIPTION
Hey,
I added a method to get the cpu. It doesn't support much (I only tested it on my linux machine and on WSL 1).  I looked at the way neofetch did it and then tried to make it POSIX. Is there a reason why CPU isn't included? Maybe the feature is already there but I missed it. I usually write bash scripts so I hopefully didn't include any bashisms or GNUisms.

![image](https://user-images.githubusercontent.com/15719059/70363595-fe3ebd00-1856-11ea-9836-07ac3d820cf0.png)
