### PR TITLE
pfetch: Add support for Bedrock

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -113,6 +113,9 @@ get_os() {
             # don't follow any os-release/lsb standards whatsoever.
             command -v crux && distro=$(crux)
             command -v guix && distro='Guix System'
+            case $PATH in
+                */bedrock/cross/*) distro='Bedrock Linux'
+            esac
 
             # Check to see if Linux is running in Windows 10 under
             # WSL1 (Windows subsystem for Linux [version 1]) and
@@ -886,6 +889,15 @@ get_ascii() {
 				${c4}  /      ,\`\\
 				${c4} /   ,.'\`.  \\
 				${c4}/.,'\`     \`'.\\
+			EOF
+        ;;
+
+        [Bb]edrock*)
+            read_ascii 4 <<-EOF
+				${c7}__
+				${c7}\\ \\___
+				${c7} \\  _ \\
+				${c7}  \\___/
 			EOF
         ;;
 


### PR DESCRIPTION
Bedrock mimics other distros.  Part of doing so involves having distro
identifiers such as /etc/os-release look like those from other distros.
It must thus be special cased to be detected properly.

Bedrock typically includes /bedrock/cross/* entries in its $PATH.
However, they may be dropped as a hint to Bedrock-aware software that
they should act as though they were not Bedrock aware.  The $PATH check
is thus used to have pfetch conditionally disable the Bedrock special
casing even on Bedrock systems.

pfetch package count detection fails to consider repeated instances of a
given package manager.  Correcting this for the Bedrock specific concern
is purposefully eschewed for the sake of simplicity.  It may be
revisited later once Bedrock's Package Manager Manager ("pmm") feature
stabilizes.
