### PR TITLE
Correct nix package path

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -497,7 +497,7 @@ get_pkgs() {
                 # 'nix' requires two commands.
                 has nix-store  && {
                     nix-store -q --requisites /run/current-system/sw
-                    nix-store -q --requisites ~.nix-profile
+                    nix-store -q --requisites ~/.nix-profile
                 }
             ;;
 


### PR DESCRIPTION
~.nix-profile doesn't exist, it should be ~/.nix-profile.

On my system (before/after corrected path):
 - Before: 504 packages
 - After: 1283 packages