### PR TITLE
Add Clippy art

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -1035,6 +1035,19 @@ get_ascii() {
 			EOF
         ;;
 
+        [Cc]lippy*)
+            read_ascii 3 <<-EOF
+				${c7} __
+				${c7}/  \\
+				${c7}|  |
+				${c7}@  @ /
+				${c7}|| ||
+				${c7}|| ||
+				${c7}|\_/|
+				${c7}\___/
+			EOF
+        ;;
+
         [Dd]ebian*)
             read_ascii 1 <<-EOF
 				${c1}  _____


### PR DESCRIPTION
Preview:

```
 __       redacted
/  \      os      Fedora 32 (Workstation Edition)
|  |      kernel  5.6.14-300.fc32.x86_64
@  @ /    shell   bash
|| ||     editor  /usr/bin/micro
|| ||     memory  4307M / 7886M
|\_/|
\___/
```

I based it on [kakaoune's ncurses assistant][1] (Unlicense license), re-drawn with only ASCII characters.

[1]: https://github.com/mawww/kakoune/blob/151eb3299d3bf3c966eaa1ff689e0866b7e08ef6/src/ncurses_ui.cc#L136-L144