### PR TITLE
Makefile: removed space between m flag and mode because of portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all:
 	@echo RUN \'make install\' to install pfetch
 
 install:
-	@install -Dm 755 pfetch $(DESTDIR)$(PREFIX)/bin/pfetch
+	@install -Dm755 pfetch $(DESTDIR)$(PREFIX)/bin/pfetch
 
 uninstall:
 	@rm -f $(DESTDIR)$(PREFIX)/bin/pfetch


### PR DESCRIPTION
Makefile didn't work on my FreeBSD machine till I removed this space. I get that it might seem a bit pendantic, but with all the effort put in to make pfetch portable I feel it's a sensible change to make.