### PR TITLE
Add iOS/iPadOS Support

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -232,9 +232,6 @@ get_os() {
                         break
                     ;;
                 esac
-            done < /System/Library/CoreServices/SystemVersion.plist
-
-            while IFS='<>' read -r _ _ line _; do
                 case $line in
                     # Match 'ProductName' and read the next line
                     # directly as it contains the key's value.

--- a/pfetch
+++ b/pfetch
@@ -234,25 +234,41 @@ get_os() {
                 esac
             done < /System/Library/CoreServices/SystemVersion.plist
 
-            # Use the ProductVersion to determine which macOS/OS X codename
-            # the system has. As far as I'm aware there's no "dynamic" way
-            # of grabbing this information.
-            case $mac_version in
-                10.4*)  distro='Mac OS X Tiger' ;;
-                10.5*)  distro='Mac OS X Leopard' ;;
-                10.6*)  distro='Mac OS X Snow Leopard' ;;
-                10.7*)  distro='Mac OS X Lion' ;;
-                10.8*)  distro='OS X Mountain Lion' ;;
-                10.9*)  distro='OS X Mavericks' ;;
-                10.10*) distro='OS X Yosemite' ;;
-                10.11*) distro='OS X El Capitan' ;;
-                10.12*) distro='macOS Sierra' ;;
-                10.13*) distro='macOS High Sierra' ;;
-                10.14*) distro='macOS Mojave' ;;
-                10.15*) distro='macOS Catalina' ;;
-                *)      distro='macOS' ;;
-            esac
+            while IFS='<>' read -r _ _ line _; do
+                case $line in
+                    # Match 'ProductName' and read the next line
+                    # directly as it contains the key's value.
+                    ProductName)
+                        IFS='<>' read -r _ _ product_name _
+                        break
+                    ;;
+                esac
+            done < /System/Library/CoreServices/SystemVersion.plist
 
+            # Detect if on MacOS or iOS/iPadOS, if on macOS then use the
+            # ProductVersion to determine which macOS/OS X codename the
+            # system has. Otherwise use ProductName fom SystemVersion.plist
+            # As far as I'm aware there's no "dynamic" way of grabbing
+            # this information.
+            if [ $product_name == "macOS" ]; then
+                case $mac_version in
+                    10.4*)  distro='Mac OS X Tiger' ;;
+                    10.5*)  distro='Mac OS X Leopard' ;;
+                    10.6*)  distro='Mac OS X Snow Leopard' ;;
+                    10.7*)  distro='Mac OS X Lion' ;;
+                    10.8*)  distro='OS X Mountain Lion' ;;
+                    10.9*)  distro='OS X Mavericks' ;;
+                    10.10*) distro='OS X Yosemite' ;;
+                    10.11*) distro='OS X El Capitan' ;;
+                    10.12*) distro='macOS Sierra' ;;
+                    10.13*) distro='macOS High Sierra' ;;
+                    10.14*) distro='macOS Mojave' ;;
+                    10.15*) distro='macOS Catalina' ;;
+                    *)      distro='macOS' ;;
+                esac
+            else
+                distro="$product_name"
+            fi
             distro="$distro $mac_version"
         ;;
 
@@ -524,6 +540,9 @@ get_pkgs() {
                     [ "$pkg_list" = "No ports are installed." ] ||
                         printf '%s\n' "$pkg_list"
                 }
+
+                # Supports iOS/iPadOS
+                has dpkg       && dpkg-query -f '.\n' -W
             ;;
 
             FreeBSD*|DragonFly*)


### PR DESCRIPTION
This gets the Product Name from /System/Library/CoreServices/SystemVersion.plist, so it should support TvOS, watchOS and all other Apple operating systems as well.