### PR TITLE
pfetch: correctly display OS version of FreeBSD

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -290,6 +290,10 @@ get_os() {
             distro="$distro $openbsd_ver"
         ;;
 
+        FreeBSD)
+            distro="$os $(freebsd-version)"
+        ;;
+
         (*)
             # Catch all to ensure '$distro' is never blank.
             # This also handles the BSDs.


### PR DESCRIPTION
Hello,

in FreeBSD, if an update doesn't update the kernel, the OS version will differ from the kernel version. Example:
```
  $ freebsd-version 
  11.4-RELEASE-p4
  $ uname -r
  11.4-RELEASE-p3
```

This patch uses freebsd-version in `get_os()`.