### PR TITLE
Generic way of obtaining hostname (missing command)

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -110,7 +110,7 @@ get_title() {
     # the intention for using it is allowing the user to overwrite the
     # value on invocation.
     # shellcheck disable=SC2039
-    hostname=${HOSTNAME:-${hostname:-$(hostname)}}
+    hostname=${HOSTNAME:-${hostname:-$(hostname || cat "/etc/hostname")}}
 
     log "[3${PF_COL3:-1}m${user}${c7}@[3${PF_COL3:-1}m${hostname}" " " >&6
 }


### PR DESCRIPTION
After a fresh install of [Arch Linux](https://www.archlinux.org/), I attempted to run `pfetch`, the **hostname** on the title section was missing, because indeed the `hostname` command didn't ship by default on this version of Arch (can't recall if it was present on older versions).

The environment variables `HOSTNAME`, `hostname` were not presented, but `HOST` was, at least on `zsh`. Tried checking if it was declared on the `dash` shell as well, it was not.
_This means the variable HOST should/may be included in the options to look for the variable as well..._
`hostname=${HOST:-${HOSTNAME:-${hostname:-$(hostname || cat "/etc/hostname")}}}`

The generic way of obtaining the hostname should be by reading the single-line-content-file located at `/etc/hostname`, as the `hostname` command's [man page](https://www.man7.org/linux/man-pages/man5/hostname.5.html) suggest.
So, if `hostname` fails `cat "/etc/hostname"` is used instead.