### PR TITLE
pfetch: correctly display pkgs on OpenBSD

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -652,8 +652,8 @@ get_pkgs() {
         (IRIX)
             packages=$((packages - 3))
         ;;
-        # OpenBSD's wc adds whitespace before the number
-        # which need to be stripped to be logged
+        # OpenBSD's wc prints whitespace before the number
+        # which needs to be stripped.
         (OpenBSD)
             packages="$(echo $packages)"
         ;;

--- a/pfetch
+++ b/pfetch
@@ -652,6 +652,11 @@ get_pkgs() {
         (IRIX)
             packages=$((packages - 3))
         ;;
+        # OpenBSD's wc adds whitespace before the number
+        # which need to be stripped to be logged
+        (OpenBSD)
+            packages="$(echo $packages)"
+        ;;
     esac
 
     case $packages in


### PR DESCRIPTION
OpenBSD's wc prints some whitespace before the number
```sh
$ printf '%s\n' /var/db/pkg/*/ | wc -l
      70
```
This breaks the `get_pkgs` function.

This pull fixes this by removing whitespace if on OpenBSD. (see diff)