### PR TITLE
Update get_editor() to strip paths from EDITOR and VISUAL

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -1017,8 +1017,14 @@ get_shell() {
 
 get_editor() {
     # Display the value of '$VISUAL', if it's empty, display the
-    # value of '$EDITOR'.
-    log editor "${VISUAL:-$EDITOR}" >&6
+    # value of '$EDITOR'. In both cases, if the value is a path,
+    # then return only the executable file name.
+    if [ "$VISUAL" ]
+    then
+        log editor "${VISUAL##*/}"
+    else
+        log editor "${EDITOR##*/}"
+    fi >&6
 }
 
 get_palette() {


### PR DESCRIPTION
## Issue
Currently, `get_editor()` reports the value of `$VISUAL`, falling back on `$EDITOR`, unaltered. This means that for someone such as myself, who uses [`export EDITOR="$(command -v vim)"`](https://github.com/yuri-norwood/dotfiles/blob/d2867a93093cacfa0e925058f1794f77f4605d63/.profile#L34), `pfetch` shows the full path to the executable.
![image](https://user-images.githubusercontent.com/76186754/104995986-fe664000-5a8b-11eb-8235-c0a20bb30c24.png)

This is in contradiction with how the `$SHELL` is reported, as the name of the executable, omitting the full path.

## Solution
To report these two values consistently, the `$VISUAL` or `$EDITOR` value should be expanded using the `${FOO##*/}` pattern. This is the [same expansion](https://github.com/dylanaraps/pfetch/blob/4498da8f54d3f7df11d0d241b89d934e90a9008f/pfetch#L1015) used by the `get_shell()` function, ensuring consistency.

Since checking for, and subsequently using `$VISUAL`, is more "correct", this behavior should be preserved. However, nesting the `${FOO##*/}` expansion, within the current `${VISUAL:-$EDITOR}` expansion is not a good idea. It is not guaranteed to work on all systems and is difficult to read. Instead, the presence of `$VISUAL` should be handled in an if statement, and the `${FOO##*/}` expansion should be reserved for the call to `log()`.

```sh
if [ "$VISUAL" ]
then
    log editor "${VISUAL##*/}"
else
    log editor "${EDITOR##*/}"
fi >&6
```

## Alternatives
This solution may lack the simplicity of the existing one-liner, so of course the alternatives must be considered.
* As mentioned before, the existing expansion may be nested within `${FOO##*/}`.
  * Pro: Preserves one-liner
  * Cons:
    * Decreased readability and maintainability
    * Not portable
* The current expansion may be stored in a temporary variable, and the new expansion may be preformed just once on that temporary variable.
  * Pro: Reduces code duplication, each expansion only written once
  * Con: Introduces an unnecessary global variable, POSIX sh lacks function locals
* A subshell may be used to inline the selection of `VISUAL` or `EDITOR`
  * Pro: Preserves one-liner
  * Con: I believe using subshells and external tools to accomplish what pure `sh` can is a shoot-able offense around here.
* The if statement may be collapsed into a chain of `&&` and `||` operators.
  * Pro: Preserves one-liner
  * Cons:
    * Reduces readability
    * Has the potential of hiding any error that occurred in the first call to `log()`
