### PR TITLE
Some .editorconfig fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,6 +2,6 @@ root = true
 
 # Force GitHub to display tabs
 # mixed with [4] spaces properly.
-[pfetch]
+[{pfetch}]
 indent_style = tab
 indent_size  = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,3 +5,7 @@ root = true
 [{pfetch}]
 indent_style = tab
 indent_size  = 4
+
+[{Makefile}]
+indent_style = tab
+


### PR DESCRIPTION
According to [EditorConfig website](https://editorconfig.org/#file-format-details)
> `[name]`  Matches any single character in name
> `{s1,s2,s3}` Matches any of the strings given (separated by commas) (Available since EditorConfig Core 0.11.0)

This means that the current rule `[pfetch]` matches more than just the `pfetch` file.

I also added a separate rule for `Makefile` as it does not accept spaces for indentation.





