### PR TITLE
Prefix '.' builtin with 'command' to prevent the script from exiting

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -1747,7 +1747,7 @@ main() {
     # Allow the user to execute their own script and modify or
     # extend pfetch's behavior.
     # shellcheck source=/dev/null
-    . "${PF_SOURCE:-/dev/null}" ||:
+    command . "${PF_SOURCE:-/dev/null}" ||:
 
     # Ensure that the 'TMPDIR' is writable as heredocs use it and
     # fail without the write permission. This was found to be the


### PR DESCRIPTION
The `.` command is a special shell builtin, meaning it will cause a non-interactive shell to exit regardless of the following `||:`.  Thus if PF_SOURCE is set to an unreadable file, pfetch will exit immediately.

The `command` builtin causes `.` to be run as if it were a regular shell builtin, preventing this issue.
