### PR TITLE
pfetch: fix shellcheck warning

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -169,7 +169,7 @@ get_title() {
     # Disable the warning about '$HOSTNAME' being undefined in POSIX sh as
     # the intention for using it is allowing the user to overwrite the
     # value on invocation.
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC3028
     host=${HOSTNAME:-${host:-$(hostname)}}
 
     # If the hostname is still not found, fallback to the contents of the


### PR DESCRIPTION
[SC2039](https://github.com/koalaman/shellcheck/wiki/SC2039) has been retired in favor of [SC3028](https://github.com/koalaman/shellcheck/wiki/SC3028).

Actual output:
```
~ $ shellcheck pfetch 

In pfetch line 173:
    host=${HOSTNAME:-${host:-$(hostname)}}
         ^-- SC3028: In POSIX sh, HOSTNAME is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3028 -- In POSIX sh, HOSTNAME is undefined.
```