### PR TITLE
Query homebrew for package list on macOS

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -604,7 +604,7 @@ get_pkgs() {
                 has dpkg       && dpkg-query -f '.\n' -W
 
                 # Directories containing packages.
-                has brew       && printf '%s\n' /usr/local/Cellar/*
+                has brew       && printf '%s\n' "$(brew --cellar)/"*
 
                 # 'port' prints a single line of output to 'stdout'
                 # when no packages are installed and exits with


### PR DESCRIPTION
Query `brew` for package list instead of using the hard-coded `/usr/local/Cellar/*` path. The homebrew installation path is configurable, and for instance, uses `/opt/homebrew` on Apple Silicon ([https://docs.brew.sh/FAQ#why-is-the-default-installation-prefix-opthomebrew-on-apple-silicon](url)).