### PR TITLE
misc: various fixes

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -170,11 +170,11 @@ get_title() {
     # the intention for using it is allowing the user to overwrite the
     # value on invocation.
     # shellcheck disable=3028,2039
-    host=${HOSTNAME:-${host:-$(hostname)}}
+    hostname=${HOSTNAME:-${hostname:-$(hostname)}}
 
     # If the hostname is still not found, fallback to the contents of the
     # /etc/hostname file.
-    [ "$host" ] || read -r host < /etc/hostname
+    [ "$hostname" ] || read -r hostname < /etc/hostname
 
     # Add escape sequences for coloring to user and host name. As we embed
     # them directly in the arguments passed to log(), we cannot use esc_p().
@@ -185,11 +185,11 @@ get_title() {
     esc SGR 1
     user=$user$e
     esc SGR 1
-    host=$e$host
+    hostname=$e$hostname
     esc SGR "3${PF_COL3:-1}"
-    host=$e$host
+    hostname=$e$hostname
 
-    log "${user}@${host}" " " >&6
+    log "${user}@${hostname}" " " >&6
 }
 
 get_os() {
@@ -379,7 +379,7 @@ get_os() {
             distro="$distro $openbsd_ver"
         ;;
 
-        FreeBSD)
+        (FreeBSD)
             distro="$os $(freebsd-version)"
         ;;
 
@@ -487,7 +487,7 @@ get_uptime() {
             IFS=. read -r s _ < /proc/uptime
         ;;
 
-        Darwin* | *BSD* | DragonFly*)
+        (Darwin* | *BSD* | DragonFly*)
             s=$(sysctl -n kern.boottime)
 
             # Extract the uptime in seconds from the following output:
@@ -560,16 +560,7 @@ get_pkgs() {
     # The output from this is then piped to 'wc -l' to count each
     # line, giving us the total package count of whatever package
     # managers are installed.
-    #
-    # Backticks are *required* here as '/bin/sh' on macOS is
-    # 'bash 3.2' and it can't handle the following:
-    #
-    # var=$(
-    #    code here
-    # )
-    #
-    # shellcheck disable=2006
-    packages=`
+    packages=$(
         case $os in
             (Linux*)
                 # Commands which print packages one per line.
@@ -658,7 +649,14 @@ get_pkgs() {
                 versions -b
             ;;
         esac | wc -l
-    `
+    )
+
+    # 'wc -l' can have leading and/or trailing whitespace
+    # depending on the implementation, so strip them.
+    # Procedure explained at https://github.com/dylanaraps/pure-sh-bible
+    # (trim-leading-and-trailing-white-space-from-string)
+    packages=${packages#"${packages%%[![:space:]]*}"}
+    packages=${packages%"${packages##*[![:space:]]}"}
 
     case $os in
         # IRIX's package manager adds 3 lines of extra
@@ -1677,7 +1675,7 @@ get_ascii() {
 			EOF
         ;;
 
-		([Xx]eonix*)
+        ([Xx]eonix*)
             read_ascii 2 <<-EOF
 				${c2}    ___  ___
 				${c2}___ \  \/  / ___


### PR DESCRIPTION
Rationale:

`$host` in `get_title()` conflicted with `get_host()`, making `${host:-$arch}` resolve to the hostname instead of substituting for the arch.

The bash 3.2 issue was specifically due to it interpreting the unbalanced parenthesis (`Linux*)`) in the case conditions as the end of the command substitution. Since they are now balanced (`(Linux*)`), this is no longer an issue.
(I actually suggested balancing them as a fix before, but since the rest of the code didn't follow that style back then, backticks ended up being used instead.)

Some implementations of `wc -l` have leading/trailing whitespace, which breaks the package count. It seems (vaguely) permitted by POSIX; see the manual and https://unix.stackexchange.com/q/205906.
Alternatively, it could be ditched altogether for a `read` loop, but performance could possibly be questionable considering that users can have thousands of packages.

The rest are just cleanup, closing some parens and converting tabs to spaces in one section.