### PR TITLE
os: SerenityOS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ picture"!
 - **Minix**
 - **Solaris**
 - **IRIX**
+- **SerenityOS**
 
 ## Configuration
 

--- a/pfetch
+++ b/pfetch
@@ -483,7 +483,7 @@ get_uptime() {
     # converting that data into days, hours and minutes using simple
     # math.
     case $os in
-        (Linux* | Minix*)
+        (Linux* | Minix* | SerenityOS*)
             IFS=. read -r s _ < /proc/uptime
         ;;
 
@@ -647,6 +647,13 @@ get_pkgs() {
 
             (IRIX)
                 versions -b
+            ;;
+
+            (SerenityOS)
+                while IFS=" " read -r type _; do
+                    [ "$type" != dependency ] &&
+                        printf "\n"
+                done < /usr/Ports/packages.db
             ;;
         esac | wc -l
     )
@@ -897,6 +904,33 @@ get_memory() {
 			EOF
 
             mem_used=$((mem_full - mem_free))
+        ;;
+
+        (SerenityOS)
+            IFS='{}' read -r _ memstat _ < /proc/memstat
+
+            set -f -- "$IFS"
+            IFS=,
+
+            for pair in $memstat; do
+                case $pair in
+                    (*user_physical_allocated*)
+                        mem_used=${pair##*:}
+                    ;;
+
+                    (*user_physical_available*)
+                        mem_free=${pair##*:}
+                    ;;
+                esac
+            done
+
+            IFS=$1
+            set +f --
+
+            mem_used=$((mem_used * 4096 / 1024 / 1024))
+            mem_free=$((mem_free * 4096 / 1024 / 1024))
+
+            mem_full=$((mem_used + mem_free))
         ;;
     esac
 
@@ -1627,6 +1661,18 @@ get_ascii() {
 				${c1}(_(_)(_)_)
 				${c1} (_(__)_)
 				${c1}   (__)
+			EOF
+        ;;
+
+        ([Ss]erenity[Oo][Ss]*)
+            read_ascii 4 <<-EOF
+				${c7}    _____
+				${c1}  ,-${c7}     -,
+				${c1} ;${c7} (       ;
+				${c1}| ${c7}. \_${c1}.,${c7}    |
+				${c1}|  ${c7}o  _${c1} ',${c7}  |
+				${c1} ;   ${c7}(_)${c1} )${c7} ;
+				${c1}  '-_____-${c7}'
 			EOF
         ;;
 


### PR DESCRIPTION
![image](http://0x0.st/-tWP.png)
https://serenityos.org/

Currently requires a POSIX-compatible shell and `sed` to be installed from ports to run, but in time these should hopefully be implemented in the base system.

*Sample input contents (does not match screenshot)*

`/proc/memstat` (no line ending):
```
{"kmalloc_allocated":1876352,"kmalloc_available":2222592,"kmalloc_eternal_allocated":2655404,"user_physical_allocated":17013,"user_physical_available":105038,"user_physical_committed":25378,"user_physical_uncommitted":79660,"super_physical_allocated":209,"super_physical_available":47,"kmalloc_call_count":468164,"kfree_call_count":454192,"slab_16_num_allocated":0,"slab_16_num_free":8192,"slab_32_num_allocated":76,"slab_32_num_free":4020,"slab_64_num_allocated":2223,"slab_64_num_free":5969,"slab_128_num_allocated":335,"slab_128_num_free":3761,"slab_256_num_allocated":0,"slab_256_num_free":512}
```

`/proc/uptime`:
```
1912
```

`/usr/Ports/packages.db`:
```
manual bash 5.1.8
manual dash 0.5.10.2
auto jq 1.6
manual neofetch 7.1.0
dependency neofetch bash jq
auto ncurses 6.2
auto libiconv 1.16
auto gettext 0.21
manual vim 8.2.2772
dependency vim ncurses gettext
auto zlib 1.2.11
manual openssl 1.1.1k
dependency openssl zlib
auto zstd 1.4.4
auto curl 7.78.0
manual git 2.33.0
dependency git zlib curl
manual sed 4.2.1
```

*Image references*

[Icon](https://raw.githubusercontent.com/SerenityOS/serenity/master/Base/res/icons/32x32/ladyball.png)
[Discord server icon](http://0x0.st/-tWZ.png)