### PR TITLE
Fix #145

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -112,8 +112,9 @@ log() {
     # End here if no data was found.
     [ "$2" ] || return
 
-    # Store the value of '$1' as we reset the argument list below.
+    # Store the values of '$1' and '$3' as we reset the argument list below.
     name=$1
+    use_seperator=$3
 
     # Use 'set --' as a means of stripping all leading and trailing
     # white-space from the info string. This also normalizes all
@@ -138,8 +139,8 @@ log() {
     printf '%s' "$name"
     esc_p SGR 0
 
-    # Print the info name and info data separator.
-    printf %s "$PF_SEP"
+    # Print the info name and info data separator, if applicable.
+    [ "$use_seperator" ] || printf %s "$PF_SEP"
 
     # Move the cursor backward the length of the *current* info name and
     # then move it forwards the length of the *longest* info name. This
@@ -189,7 +190,7 @@ get_title() {
     esc SGR "3${PF_COL3:-1}"
     hostname=$e$hostname
 
-    log "${user}@${hostname}" " " >&6
+    log "${user}@${hostname}" " " " " >&6
 }
 
 get_os() {
@@ -1058,10 +1059,10 @@ get_palette() {
         palette="$palette$e"
     }
 
-    # Print the palette with a new-line before and afterwards.
+    # Print the palette with a new-line before and afterwards but no seperator.
     printf '\n' >&6
     log "$palette
-        " " " >&6
+        " " " " " >&6
 }
 
 get_ascii() {


### PR DESCRIPTION
Adds an extra argument to `log()` that tells the function not to output any separator, fixing the redundant separators on `title` and `palette`.