### PR TITLE
Fixed issue with `read` when a file does not exist.

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -412,9 +412,11 @@ get_host() {
             # Despite what these files are called, version doesn't
             # always contain the version nor does name always contain
             # the name.
-            read -r name    < /sys/devices/virtual/dmi/id/product_name
-            read -r version < /sys/devices/virtual/dmi/id/product_version
-            read -r model   < /sys/firmware/devicetree/base/model
+			# NOTE: Using `printf` in order to prevent `read` from reading stdout
+			# when some of these files do not exist.
+            name=$(printf "%s" "$(< /sys/devices/virtual/dmi/id/product_name)")
+            version=$(printf "%s" "$(< /sys/devices/virtual/dmi/id/product_version)")
+            model=$(printf "%s" "$(< /sys/firmware/devicetree/base/model)")
 
             host="$name $version $model"
         ;;


### PR DESCRIPTION
When using `pfetch` on my Raspberry Pi I noticed that the host contained some weird information.
```
 uptime 1h 5m
 host   uptime Raspberry Pi 3 Model B Plus Rev 1.3
``` 
I looked into the issue and I think it was because when `read` tries to read from a file that does not
exist (in this case: product_name and product_version) it reads from stdout and stores it in the
variable. 
Although `echo` has a simpler syntax and also works fine, I used `printf` as it is much well defined
in the POSIX standard and also does not add  a newline automatically (although this does not seem
to be an issue).

Tested on my Raspberry Pi which uses the dash shell and on my laptop (Solus) which uses the bash shell.