### PR TITLE
Fix default PF_COL2, closes #147

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ PF_COL1=4
 # Color of info data:
 # Default: unset (auto)
 # Valid: 0-9
-PF_COL2=7
+PF_COL2=9
 
 # Color of title data:
 # Default: unset (auto)

--- a/pfetch
+++ b/pfetch
@@ -150,7 +150,7 @@ log() {
 
     # Print the info data, color it and strip all leading whitespace
     # from the string.
-    esc_p SGR "3${PF_COL2-7}"
+    esc_p SGR "3${PF_COL2-9}"
     printf '%s' "$info"
     esc_p SGR 0
     printf '\n'


### PR DESCRIPTION
Previously, the default value of PF_COL2 was 7 (white); this was an issue for light-themed terminals (#147). This PR changes the default value to 9, so pfetch uses the terminal's default color.