### PR TITLE
Add Solus ascii art

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ picture"!
 ## OS support
 
 - **Linux**
-    - Alpine Linux, Arch Linux, Arco Linux, Artix Linux, CentOS, Dahlia, Debian, Elementary, Fedora, Gentoo, Guix, Hyperbola, instantOS, KISS Linux, Linux Lite, Linux Mint, Mageia, Manjaro, MX Linux, NixOS, OpenSUSE, Parabola, Pop!\_OS, PureOS, Slackware, Ubuntu and Void Linux.
+    - Alpine Linux, Arch Linux, Arco Linux, Artix Linux, CentOS, Dahlia, Debian, Devuan, Elementary, Fedora, Gentoo, Guix, Hyperbola, instantOS, KISS Linux, Linux Lite, Linux Mint, Mageia, Manjaro, MX Linux, NixOS, OpenSUSE, Parabola, Pop!\_OS, PureOS, Slackware, Solus, Ubuntu and Void Linux.
     - All other distributions are supported with a generic penguin logo.
 - **Android**
 - **BSD**

--- a/pfetch
+++ b/pfetch
@@ -1718,6 +1718,18 @@ get_ascii() {
 			EOF
         ;;
 
+        ([Ss]olus*)
+            read_ascii 4 <<-EOF
+				${c6} 
+				${c6}     /|
+				${c6}    / |\\
+				${c6}   /  | \\ _
+				${c6}  /___|__\\_\\
+				${c6} \\         /
+				${c6}  \`-------´
+			EOF
+        ;;
+
         ([Ss]un[Oo][Ss]|[Ss]olaris*)
             read_ascii 3 <<-EOF
 				${c3}       .   .;   .

--- a/pfetch
+++ b/pfetch
@@ -1282,6 +1282,18 @@ get_ascii() {
 			EOF
         ;;
 
+		([Dd]evuan*)
+			read_ascii 6 <<-EOF
+				${c4} ..:::.      
+				${c4}    ..-==-   
+				${c4}        .+#: 
+				${c4}         =@@ 
+				${c4}      :+%@#: 
+				${c4}.:=+#@@%*:   
+				${c4}#@@@#=:      
+			EOF
+		;;
+
         ([Dd]ragon[Ff]ly*)
             read_ascii 1 <<-EOF
 				    ,${c1}_${c7},


### PR DESCRIPTION
Ascii art logo for Solus which has been suggested in #63 but never added. For me, it appeared correctly on a Solus live CD.