### PR TITLE
Fixed RAM usage info (Issue #186)

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -711,26 +711,10 @@ get_memory() {
                     (MemFree | Buffers | Cached | SReclaimable)
                         mem_used=$((mem_used - val))
                     ;;
-
-                    # If detected this will be used over the above calculation
-                    # for mem_used. Available since Linux 3.14rc.
-                    # See kernel commit 34e431b0ae398fc54ea69ff85ec700722c9da773
-                    (MemAvailable)
-                        mem_avail=$val
-                    ;;
                 esac
             done < /proc/meminfo
 
-            case $mem_avail in
-                (*[0-9]*)
-                    mem_used=$(((mem_full - mem_avail) / 1024))
-                ;;
-
-                *)
-                    mem_used=$((mem_used / 1024))
-                ;;
-            esac
-
+            mem_used=$((mem_used / 1024))
             mem_full=$((mem_full / 1024))
         ;;
 


### PR DESCRIPTION
Removed calculations around MemAvailable that were distortring used RAM info, increasing it by approximately 200 MiBs.

It now conforms to htop's and neofetch's output:

```
  _____   
 /  __ \     os     Debian GNU/Linux 11 (bullseye)
|  /    |    host   X541NC 1.0
|  \___-     kernel 5.10.0-12-amd64
-_           uptime 57m
  --_        pkgs   2530
             memory 1929M / 3794M
```
  
</br>

![2022-03-22_16:18:31](https://user-images.githubusercontent.com/72746829/159516520-29ef617b-1b2e-48f6-83e0-92b0f75f2c31.png)

