### PR TITLE
Display fedora logo when using nobara

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -1329,7 +1329,7 @@ get_ascii() {
 			EOF
         ;;
 
-        ([Ff]edora*)
+        ([Ff]edora*|[Nn]obara*)
             read_ascii 4 <<-EOF
 				        ${c4},'''''.
 				       ${c4}|   ,.  |


### PR DESCRIPTION
Gloriouseggrolls' [Nobara Project](https://nobaraproject.org/), which is based on Fedora, has had the Fedora Linux logo in pfetch until recently, when the distribution release name was changed to Nobara Linux. Since the distro does not seem to have an official logo yet, it would be prettier to display the fedora logo instead of the default linux one.