### PR TITLE
Updated pfetch - macOS Ventura will now be recognized as such

### DIFF
--- a/pfetch
+++ b/pfetch
@@ -340,6 +340,7 @@ get_os() {
                 (10.15*) distro='macOS Catalina' ;;
                 (11*)    distro='macOS Big Sur' ;;
                 (12*)    distro='macOS Monterey' ;;
+				(13*)    distro='macOS Ventura' ;;
                 (*)      distro='macOS' ;;
             esac
 


### PR DESCRIPTION
I added macOS Ventura to pfetch. Executing it on Ventura will now show "macOS Ventura" instead of "macOS"